### PR TITLE
Clicking icon switches back

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Automatic arxiv->ar5iv link replacement in Chrome.
 
-This chrome extension will automatically replace arxiv.org/pdf/* links with ar5iv links for more web-friendly reading.
+This chrome extension will automatically replace arxiv.org/pdf/* links with ar5iv links for more web-friendly reading. Additionally, clicking on the extension's icon will take you to the alternate version.
 
 ## Installation
 
-1. Clone the repo `git@github.com:yobibyte/rct.git`
+1. Clone the repo `git@github.com:yobibyte/ar5iv_chrome_ext.git`
 
 2. Go to `chrome://extensions/` and turn on the developer mode
 
@@ -22,3 +22,4 @@ https://arxiv.org/pdf/2010.01856.pdf
 https://arxiv.org/pdf/2010.01856.pdf?forcepdf
 
 ```
+Alternatively, you can click the icon to get back to the arxiv pdf from ar5iv.

--- a/background.js
+++ b/background.js
@@ -1,8 +1,23 @@
+var manual_switch = false; // flag set to true when the extension icon has been clicked
+
+// Callback intercepts initial arxiv page load and switches to ar5iv
 var callback = function(details) {
-    if (details.url.endsWith("?forcepdf")) {
+    if (details.url.endsWith("?forcepdf") || manual_switch) {
         return;
     }
     return {redirectUrl: details.url.replace("arxiv", "ar5iv")};
 }
 var filter= {urls: ["*://arxiv.org/pdf/*", "*://www.arxiv.org/pdf/*"]}
 chrome.webRequest.onBeforeRequest.addListener(callback, filter, ["blocking"]);
+
+// When the extension icon is clicked, switch back to pdf / ar5iv 
+// TODO icon depending on which is being viewed
+var switch_view = function(tab) {
+    manual_switch = true;
+    if (tab.url.includes("arxiv.org/pdf/"))   { // arxiv -> ar5iv
+        chrome.tabs.update(tab.id, {url: tab.url.replace("arxiv", "ar5iv")});
+    } else if (tab.url.includes("ar5iv.org")) { // ar5iv -> arxiv
+        chrome.tabs.update(tab.id, {url: tab.url.replace("ar5iv.org/html/", "arxiv.org/pdf/")});
+    }
+}
+chrome.browserAction.onClicked.addListener(tab => switch_view(tab));

--- a/manifest.json
+++ b/manifest.json
@@ -9,11 +9,16 @@
     "scripts": ["background.js"],
     "persistent": true
   },
+  "browser_action": {
+    "default_icon": "icon128.png"
+  },
   "permissions": [
     "webRequest",
     "*://arxiv.org/*",
     "*://www.arxiv.org/*",
-    "webRequestBlocking"
+    "webRequestBlocking",
+    "*://ar5iv.org/*",
+    "*://www.ar5iv.org/*"
   ],
   "icons": {"128": "icon128.png"}
 }


### PR DESCRIPTION
Clicking the icon now switches you back to arxiv pdf from ar5iv. Clicking again will cycle the view back.

Also updated readme with correct repo link and details about icon clicking (phrasing is quite bad)